### PR TITLE
Fix abs builtin return type handling

### DIFF
--- a/src/main/java/mu/EvalVisitor.java
+++ b/src/main/java/mu/EvalVisitor.java
@@ -835,9 +835,14 @@ public class EvalVisitor extends MuBaseVisitor<Value> {
                 if (!absValue.isNumeric()) {
                     throw new RuntimeException("abs expects a numeric argument");
                 }
-                double absNumber = absValue.isDouble() ? absValue.asDouble() : absValue.asInteger();
-                Value absResult = new Value(Math.abs(absNumber));
-                absResult.type = Value.TYPE.FLOAT;
+                if (absValue.isDouble()) {
+                    Value absResult = new Value(Math.abs(absValue.asDouble()));
+                    absResult.type = Value.TYPE.FLOAT;
+                    return absResult;
+                }
+
+                Value absResult = new Value(Math.abs(absValue.asInteger()));
+                absResult.type = Value.TYPE.INT;
                 return absResult;
 
             case "pow":


### PR DESCRIPTION
## Summary
- update the `abs` builtin so integer inputs yield integer results instead of forcing a float

## Testing
- `mvn -q test` *(fails: unable to download org.antlr:antlr4-maven-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b0c3064883239d07a68c780588e5